### PR TITLE
Adding support for CORS with any domain, need to restrict this in fut…

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ An AI pipeline to validate W9 tax forms. Built on the following technologies:
 To run the API, run:
 
 ```
- uv run uvicorn server:app --reload --host 0.0.0.0 --port 8080
- ```
+    uv run uvicorn server:app --reload --host 0.0.0.0 --port 8080
+```
 
 
 To run the frontend, run:
 
 ```
-cd client
-npm run dev
+    cd client
+    npm run dev
 ```

--- a/README.md
+++ b/README.md
@@ -11,5 +11,13 @@ An AI pipeline to validate W9 tax forms. Built on the following technologies:
 To run the API, run:
 
 ```
- uv run uvicorn server:app --reload --port 8080
+ uv run uvicorn server:app --reload --host 0.0.0.0 --port 8080
  ```
+
+
+To run the frontend, run:
+
+```
+cd client
+npm run dev
+```

--- a/api/main.py
+++ b/api/main.py
@@ -1,15 +1,26 @@
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from api.routes.router import router
-import dotenv
-
-dotenv.load_dotenv()
+from fastapi.middleware.cors import CORSMiddleware
 
 def create_app():
+
     app = FastAPI(
         title="W9 Validator API",
         version="1.0",
         description="W9 Validator API"
+    )
+
+    origins = [
+        "*"
+    ]
+
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
     )
 
     app.include_router(router)

--- a/client/src/service/validation.service.ts
+++ b/client/src/service/validation.service.ts
@@ -1,7 +1,7 @@
 import { IValidateResponse } from "../features/upload/store/upload.types";
 import { ApiService } from "./api.service";
 
-const validateTaxFormUrl = `http://localhost:8080/w9-validator/v1/validator`;
+const validateTaxFormUrl = `http://192.168.68.71:8080/w9-validator/v1/validator`;
 
 class ValidationService extends ApiService {
   async validateTaxForm(body: FormData): Promise<IValidateResponse> {
@@ -10,3 +10,4 @@ class ValidationService extends ApiService {
 }
 
 export default ValidationService;
+

--- a/client/src/service/validation.service.ts
+++ b/client/src/service/validation.service.ts
@@ -1,7 +1,7 @@
 import { IValidateResponse } from "../features/upload/store/upload.types";
 import { ApiService } from "./api.service";
 
-const validateTaxFormUrl = `http://192.168.68.71:8080/w9-validator/v1/validator`;
+const validateTaxFormUrl = `http://localhost:8080/w9-validator/v1/validator`;
 
 class ValidationService extends ApiService {
   async validateTaxForm(body: FormData): Promise<IValidateResponse> {

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -4,4 +4,7 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server:{
+      host: '0.0.0.0'
+  }
 })

--- a/server.py
+++ b/server.py
@@ -1,5 +1,8 @@
 import uvicorn
 from api.main import create_app
+import dotenv
+dotenv.load_dotenv()
+
 
 # Initialize the FastAPI server
 app = create_app()


### PR DESCRIPTION
- Allow vite to serve on any ip so that you can test from a mobile device
- Allow CORS, keeping it wildcard for now, should restrict and get the list from a props file later on